### PR TITLE
Fix exception when content_type array index does not exist

### DIFF
--- a/php/workbooks_api.php
+++ b/php/workbooks_api.php
@@ -1174,8 +1174,15 @@ class WorkbooksApi
       $objs = array($objs);
     }  
     
+    $urlencode = true;   
+
+      if (array_key_exists('content_type',$options)) {
+        $urlencode = !(@$options['content_type'] == WorkbooksApi::FORM_DATA);
+      } 
+
     $filter_params = $this->encodeMethodParams($objs, $method);
-    $ordered_post_params = $this->fullSquare($objs, !(@$options['content_type'] == WorkbooksApi::FORM_DATA));
+    $ordered_post_params = $this->fullSquare($objs, $urlencode);
+    
     $response = $this->apiCall($endpoint, 'PUT', $params, array_merge($filter_params, $ordered_post_params), $options);
 
     // $this->log('batch() returns', $response, 'info');
@@ -1948,5 +1955,3 @@ if (isset($params) &&
   // Turn output buffering on
   ob_start();
 }
-
-?>


### PR DESCRIPTION
When the batch function is called in workbooks_api.php an exception is thrown if the $options['content_ype'] index does not exist. Although this is not fatal it is not desirable. The patch checks for the existence of the array key and sets a variable to workaround the problem.